### PR TITLE
Add new parameter `additional_headers"

### DIFF
--- a/alice/config.py
+++ b/alice/config.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Dict
 
 
 @dataclass
@@ -9,3 +10,4 @@ class Config:
     api_key: str = None
     sandbox_token: str = None
     send_agent: bool = True
+    additional_headers: Dict = None

--- a/alice/onboarding/onboarding.py
+++ b/alice/onboarding/onboarding.py
@@ -1,16 +1,15 @@
 from typing import List, Dict
-from enum import Enum
 
 from meiga import Result, Success, Failure, isSuccess
 
+from alice.auth.auth import Auth
 from alice.config import Config
 from alice.onboarding.decision import Decision
+from alice.onboarding.device_info import DeviceInfo
 from alice.onboarding.document_source import DocumentSource
+from alice.onboarding.onboarding_client import OnboardingClient
 from alice.onboarding.onboarding_errors import OnboardingError
 from alice.onboarding.user_info import UserInfo
-from alice.onboarding.device_info import DeviceInfo
-from alice.onboarding.onboarding_client import OnboardingClient
-from alice.auth.auth import Auth
 
 DEFAULT_URL = "https://apis.alicebiometrics.com/onboarding"
 
@@ -22,11 +21,21 @@ class Onboarding:
             auth=Auth.from_config(config),
             url=config.onboarding_url,
             send_agent=config.send_agent,
+            additional_headers=config.additional_headers,
         )
 
-    def __init__(self, auth: Auth, url: str = DEFAULT_URL, send_agent: bool = True):
+    def __init__(
+        self,
+        auth: Auth,
+        url: str = DEFAULT_URL,
+        send_agent: bool = True,
+        additional_headers: Dict = None,
+    ):
         self.onboarding_client = OnboardingClient(
-            auth=auth, url=url, send_agent=send_agent
+            auth=auth,
+            url=url,
+            send_agent=send_agent,
+            additional_headers=additional_headers,
         )
         self.url = url
 

--- a/alice/onboarding/onboarding_client.py
+++ b/alice/onboarding/onboarding_client.py
@@ -3,7 +3,7 @@ import platform
 
 import requests
 from requests import Response
-from typing import List
+from typing import List, Dict
 
 from alice.auth.auth import Auth
 from alice.onboarding.decision import Decision
@@ -18,10 +18,17 @@ DEFAULT_URL = "https://apis.alicebiometrics.com/auth"
 
 
 class OnboardingClient:
-    def __init__(self, auth: Auth, url: str = DEFAULT_URL, send_agent: bool = True):
+    def __init__(
+        self,
+        auth: Auth,
+        url: str = DEFAULT_URL,
+        send_agent: bool = True,
+        additional_headers: Dict = None,
+    ):
         self.auth = auth
         self.url = url
         self.send_agent = send_agent
+        self.additional_headers = additional_headers
 
     def _auth_headers(self, token: str):
         auth_headers = {"Authorization": f"Bearer {token}"}
@@ -31,6 +38,8 @@ class OnboardingClient:
                     "Alice-User-Agent": f"onboarding-python/{alice.__version__} ({platform.system()}; {platform.release()}) python {platform.python_version()}"
                 }
             )
+        if self.additional_headers:
+            auth_headers.update(self.additional_headers)
         return auth_headers
 
     @timeit
@@ -52,7 +61,6 @@ class OnboardingClient:
         print_intro("healthcheck", verbose=verbose)
 
         response = requests.get(f"{self.url}/healthcheck")
-        
 
         print_response(response=response, verbose=verbose)
 

--- a/alice/public_api.py
+++ b/alice/public_api.py
@@ -36,7 +36,7 @@ classes = [
     "Webhooks",
     "WebhooksClient",
     "Webhook",
-    "Decision"
+    "Decision",
 ]
 
 


### PR DESCRIPTION
Add it to `Config`, `Onboarding` and `OnboardingClient` to allow
injecting headers to the onboarding requests

This is necessary for targeting canary versions