### PR TITLE
FIX. Remove wrong inheritance in config class

### DIFF
--- a/alice/config.py
+++ b/alice/config.py
@@ -1,11 +1,10 @@
 from typing import Optional
 
-from meiga import Error
 from pydantic.dataclasses import dataclass
 
 
 @dataclass
-class Config(Error):
+class Config:
     onboarding_url: str = "https://apis.alicebiometrics.com/onboarding"
     sandbox_url: str = "https://apis.alicebiometrics.com/onboarding/sandbox"
     api_key: str = None


### PR DESCRIPTION
This error doesn't seem to break nothing because it has `dataclass` decorator but pycharm was complaining and I noticed it